### PR TITLE
More performant way of linting bang consistency

### DIFF
--- a/doc/dev.md
+++ b/doc/dev.md
@@ -93,6 +93,11 @@ The alias `cider-nrepl` is defined in his `~/.clojure/deps.edn`:
              "[cider.nrepl/cider-middleware,refactor-nrepl.middleware/wrap-refactor]"]}
 ```
 
+## Coding guidelines
+
+- Avoid calling rewrite-clj `sexpr` when you can. This often results in exceptions when the code is not representable as a sexpr, e.g.: `{:a}`. This becomes noticable when you use clj-kondo in an editor and you stop typ
+- Avoid traversing the AST multiple times if possible. 
+
 ## Tests
 
 To test clj-kondo on the JVM, run:

--- a/doc/dev.md
+++ b/doc/dev.md
@@ -1,5 +1,9 @@
 # Developer documentation
 
+## Project board
+
+All issues are categorized in a column on the [project board](https://github.com/borkdude/clj-kondo/projects/1).
+
 ## Design principles
 
 1) Linters should be designed to add value in both of these modes:
@@ -30,6 +34,10 @@ If you wish to add a new linter, do not forget to add the appropriate keyword in
 This is necessary because only the linters with a keyword in the default config appear in the report.  
 
 ## PR
+
+### Issue
+
+Before creating a code PR, please create an issue first that describes the problem you are trying to solve, alternatives that you have considered, etc. A little bit of prior communication can save a lot of time on coding.
 
 ### Linting diff
 

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -360,11 +360,6 @@
         ;; "my-fn docstring" {:no-doc true} [x y z] x
         [name-node & children] (next (:children expr))
         name-node (when name-node (meta/lift-meta-content2 ctx name-node))
-        fn-name (when name-node
-                  (when-let [fn-name (:value name-node)]
-                    (with-meta
-                      fn-name
-                      (meta name-node))))
         call (name (symbol-call expr))
         var-meta (meta name-node)
         meta-node (when-let [fc (first children)]
@@ -399,6 +394,13 @@
                                                :syntax
                                                "Invalid function body.")))
         ;; var is known when making recursive call
+        fn-name (when name-node
+                  (when-let [fn-name (:value name-node)]
+                    (with-meta
+                      fn-name
+                      (assoc (meta name-node)
+                             :test (:test ctx)
+                             :macro macro?))))
         _ (when fn-name
             (namespace/reg-var!
              ctx ns-name fn-name expr {:temp true}))
@@ -432,7 +434,8 @@
                    :arities arities
                    :varargs-min-arity varargs-min-arity
                    :doc docstring
-                   :added (:added var-meta))))
+                   :added (:added var-meta)
+                   :test (:test ctx))))
     (mapcat :parsed parsed-bodies)))
 
 (defn analyze-case [ctx expr]

--- a/src/clj_kondo/impl/analyzer/test.clj
+++ b/src/clj_kondo/impl/analyzer/test.clj
@@ -6,7 +6,7 @@
 
 (defn analyze-deftest [ctx deftest-ns expr]
   (common/analyze-defn
-   ctx
+   (assoc ctx :test true)
    (-> expr
        (update
         :children

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -75,7 +75,8 @@
                                  ;; warn when alias for clojure.string is
                                  ;; different from str
                                  :aliases {#_clojure.string #_str}}
-              :unused-import {:level :warning}}
+              :unused-import {:level :warning}
+              :single-operand-comparison {:level :warning}}
     :lint-as {cats.core/->= clojure.core/->
               cats.core/->>= clojure.core/->>
               rewrite-clj.custom-zipper.core/defn-switchable clojure.core/defn

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -75,7 +75,8 @@
                                  ;; warn when alias for clojure.string is
                                  ;; different from str
                                  :aliases {#_clojure.string #_str}}
-              :unused-import {:level :warning}}
+              :unused-import {:level :warning}
+              :bang-suffix-consistency {:level :off}}
     :lint-as {cats.core/->= clojure.core/->
               cats.core/->>= clojure.core/->>
               rewrite-clj.custom-zipper.core/defn-switchable clojure.core/defn

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -234,7 +234,10 @@
                                                         call-lang)
                                                       in-def
                                                       called-fn))
-                             _ (lint-bangs! ctx filename fn-name in-def)]
+                             _ (when (not (utils/linter-disabled? call :bang-suffix-consistency))
+                                 (let [m (meta in-def)]
+                                   (when-not (:test m)
+                                     (lint-bangs! ctx filename fn-name in-def))))]
                        :when valid-call?
                        :let [fn-name (:name called-fn)
                              _ (when (and unresolved?

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -140,6 +140,26 @@
           (if (= 1 called-with) "arg" "args")
           (show-arities fixed-arities varargs-min-arity)))
 
+(defn lint-single-operand-comparison
+  "Lints calls of single operand comparisons with always the same vlaue."
+  [call]
+  (let [ns-name (:resolved-ns call)
+        core-ns (utils/one-of ns-name [clojure.core cljs.core])]
+    (when core-ns
+      (let [fn-name (:name call)
+            const-true (utils/one-of fn-name [= > < >= <= ==])
+            const-false (= 'not= fn-name)]
+        (when (and (or const-true const-false)
+                   (= 1 (:arity call)))
+          (node->line
+           (:filename call)
+           (:expr call)
+           :warning
+           :single-operand-comparison
+           (format "Single operand use of %s is always %s"
+                   (str ns-name "/" fn-name)
+                   (some? const-true))))))))
+
 (defn lint-var-usage
   "Lints calls for arity errors, private calls errors. Also dispatches
   to call-specific linters."
@@ -246,6 +266,10 @@
                                   varargs-min-arity)
                               (not (or (contains? fixed-arities arity)
                                        (and varargs-min-arity (>= arity varargs-min-arity)))))
+                             single-operand-comparison-error
+                             (and call?
+                                  (not (utils/linter-disabled? call :single-operand-comparison))
+                                  (lint-single-operand-comparison call))
                              errors
                              [(when arity-error?
                                 {:filename filename
@@ -255,6 +279,8 @@
                                  :end-col end-col
                                  :type :invalid-arity
                                  :message (arity-error fn-ns fn-name arity fixed-arities varargs-min-arity)})
+                              (when single-operand-comparison-error
+                                single-operand-comparison-error)
                               (when (and (:private called-fn)
                                          (not= caller-ns-sym
                                                fn-ns)

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -2507,7 +2507,16 @@
     "(defn a ([] (b)))"                                          :valid
     "(defn a ([] (b)) ([x] (c)))"                                :valid
     "(defn a! [] (b!))"                                          :valid
-    "(defn a! [] (b))"                                           :valid))
+    "(defn a! [] (b))"                                           :valid)
+  (assert-submaps
+   '({:file "<stdin>", :row 1, :col 20, :level :warning, :message #"should also be !-suffixed"})
+   (lint! "(defn b! []) (defn a [] (b!))"
+          {:linters {:bang-suffix-consistency {:level :warning}}}))
+  (testing "Linter is disabled by default"
+    (is (empty? (lint! "(defn b! []) (defn a [] (b!))"))))
+  (testing "Tests are excluded from this linter"
+    (is (empty? (lint! "(require '[clojure.test :as t]) (t/deftest foo (swap! (atom nil) identity))"
+                       '{:linters {:bang-suffix-consistency {:level :warning}}})))))
 
 ;;;; Scratch
 

--- a/test/clj_kondo/single_operand_comparison_test.clj
+++ b/test/clj_kondo/single_operand_comparison_test.clj
@@ -1,0 +1,42 @@
+(ns clj-kondo.single-operand-comparison-test
+  (:require
+   [clj-kondo.test-utils :refer [lint! assert-submaps]]
+   [clojure.test :as t :refer [deftest is testing]]))
+
+(deftest single-operand-comparison-test
+  (testing "test full linting error for single operand comparison in clojure"
+    (assert-submaps
+     '({:file "<stdin>", :row 1, :col 1, :level :warning,
+        :message "Single operand use of clojure.core/= is always true"})
+     (lint! "(= 1)")))
+
+  (testing "test full linting error for single operand comparison in cljs"
+    (assert-submaps
+     '({:file "<stdin>", :row 1, :col 1, :level :warning,
+        :message "Single operand use of cljs.core/not= is always false"})
+     (lint! "(not= 1)" "--lang" "cljs")))
+
+  (testing "test linting comparison operators with single operand"
+    (doseq [lang ["clj" "cljs"]
+            op ["=" ">" "<" ">=" "<=" "=="]
+            :let [errors (lint! (str "(" op " 1)") "--lang" lang)]]
+      (is (= 1 (count errors)))
+      (is (= (format "Single operand use of %s.core/%s is always true"
+                     (get {"clj" "clojure"} lang "cljs")
+                     op)
+             (-> errors
+                 (first)
+                 :message)))))
+
+  (testing "test linting single operand comparison in threading macros"
+    (is (seq (lint! "(-> 10 (>))")))
+    (is (seq (lint! "(->> 10 (>))")))
+    (is (seq (lint! "(def x 11)(->> x (+ 1) (>))"))))
+
+  (testing "test linting single operand comparison for valid expressions"
+    (doseq [expr ["(= 1 2)"
+                  "(= (== 1 2) false)"
+                  "(-> 10 (> 20))"
+                  "(->> 10 (< 20))"
+                  "(def x 11)(->> x (+ 1) (> 2))"]]
+      (is (empty? (lint! expr))))))


### PR DESCRIPTION
This moves the bang checker to linters.clj. 
This avoids having to call rewrite-clj.nodes/sexpr which is an expensive and unsafe operation.
This avoids an extra traversal of the AST for this linter, which yields suboptimal performance.